### PR TITLE
Adds new options

### DIFF
--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -113,6 +113,17 @@ module Warden
             default: {},
             constructor: ->(value) { constantize_values(symbolize_keys(value)) })
 
+    # Array of valid values for the `aud` claim on tokens. If set, `aud_header`
+    # logic is bypassed.
+    #
+    # @example
+    # ["inbound-api-access"]
+    setting(:valid_auds, default: [])
+
+    # Default scope for tokens. If set, tokens without an `scp` claim will take
+    # this value instead.
+    setting :default_scope
+
     Import = Dry::AutoInject(config)
   end
 end

--- a/lib/warden/jwt_auth/errors.rb
+++ b/lib/warden/jwt_auth/errors.rb
@@ -17,6 +17,16 @@ module Warden
       class WrongScope < JWT::DecodeError
       end
 
+      # Error raised when trying to decode a token without scope claim and 
+      # no default_scope set
+      class MissingScopeWithNoDefaultFallback < JWT::DecodeError
+      end
+
+      # Error raised when trying to decode a token with aud_header not being specified
+      # and no valid_auds set
+      class MissingAudHeaderWithNoFallback < JWT::DecodeError
+      end
+
       # Error raised when trying to decode a token which `aud` claim does not
       # match with the expected one
       class WrongAud < JWT::DecodeError

--- a/lib/warden/jwt_auth/payload_user_helper.rb
+++ b/lib/warden/jwt_auth/payload_user_helper.rb
@@ -17,6 +17,7 @@ module Warden
 
       # Returns whether given scope matches with the one encoded in the payload
       # @param payload [Hash] JWT payload
+      # @param scope [Symbol] A Warden scope
       # @return [Boolean]
       def self.scope_matches?(payload, scope)
         payload['scp'] == scope.to_s
@@ -24,9 +25,17 @@ module Warden
 
       # Returns whether given aud matches with the one encoded in the payload
       # @param payload [Hash] JWT payload
+      # @param aud [String] The aud to match
       # @return [Boolean]
       def self.aud_matches?(payload, aud)
         payload['aud'] == aud
+      end
+
+      # Returns whether given payload's aud claim matches one of the valid_auds setting
+      # @param payload [Hash] JWT payload
+      # @return [Boolean]
+      def self.aud_matches_valid_ones?(payload)
+        JWTAuth.config.valid_auds.include?(payload['aud'])
       end
 
       # Returns whether given issuer matches with the one encoded in the payload

--- a/lib/warden/jwt_auth/version.rb
+++ b/lib/warden/jwt_auth/version.rb
@@ -2,6 +2,6 @@
 
 module Warden
   module JWTAuth
-    VERSION = '0.9.0'
+    VERSION = '0.11.0'
   end
 end


### PR DESCRIPTION
This PR introduces two new behaviors and accompanying settings to Warden::JWTAuth.

First, the `valid_auds` setting. Upstream, if the token has an `aud` claim, we [need a second header](https://github.com/waiting-for-dev/warden-jwt_auth/blob/master/README.md#requesting-client-validation) (by default, `JWT_AUD`) and its value must match the claim - this is only bypassed when the `aud` claim is nil. With this PR, we instead allow for empty `aud_header` values and instead match the `aud` claim to a set of valid ones. This setting should be an array:

```ruby
config.jwt do |jwt|
    jwt.valid_auds = [
      "private-api"
    ]
end
```

Second, the upstream gem [forces us to have an `scp` claim on tokens](https://github.com/waiting-for-dev/warden-jwt_auth/blob/master/lib/warden/jwt_auth/user_decoder.rb#L43) to match a valid Devise mapping. This PR adds a default value for this claim when it's not present. 

```ruby
config.jwt do |jwt|
    jwt.default_scope = 'user_account'
end
```

No test cover this new behavior (yet) but they will need to be added for the upstream to accept these changes.