### PR TITLE
allow rails dependency version above 6

### DIFF
--- a/lib/warden/jwt_auth.rb
+++ b/lib/warden/jwt_auth.rb
@@ -53,7 +53,7 @@ module Warden
       self.class.jwks
     end
 
-    module_function :init_jkws_loader, :constantize_values, :symbolize_keys, :upcase_first_items
+    module_function :init_jkws_loader, :constantize_values, :symbolize_keys, :upcase_first_items # rubocop:disable Style/AccessModifierDeclarations
 
     # The secret used to encode the token
     setting :secret

--- a/lib/warden/jwt_auth/version.rb
+++ b/lib/warden/jwt_auth/version.rb
@@ -2,6 +2,6 @@
 
 module Warden
   module JWTAuth
-    VERSION = '0.12.5'
+    VERSION = '0.12.6'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,11 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'warden/jwt_auth'
-require 'pry-byebug'
+begin
+  require 'pry-byebug'
+rescue LoadError
+  # Skip pry-byebug if Readline is not available
+end
 require 'simplecov'
 
 SimpleCov.start

--- a/warden-jwt_auth.gemspec
+++ b/warden-jwt_auth.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jwt', '~> 2.1'
   spec.add_dependency 'warden', '~> 1.2'
   # for JWKS caching
-  spec.add_dependency 'rails', '>= 6', '< 9'
+  spec.add_dependency 'rails', '~> 7.0.6'
   # for logging
   spec.add_dependency 'rails_semantic_logger', '~> 4.12'
 

--- a/warden-jwt_auth.gemspec
+++ b/warden-jwt_auth.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jwt', '~> 2.1'
   spec.add_dependency 'warden', '~> 1.2'
   # for JWKS caching
-  spec.add_dependency 'rails', '~> 6'
+  spec.add_dependency 'rails', '>= 6', '< 9'
   # for logging
   spec.add_dependency 'rails_semantic_logger', '~> 4.12'
 

--- a/warden-jwt_auth.gemspec
+++ b/warden-jwt_auth.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jwt', '~> 2.1'
   spec.add_dependency 'warden', '~> 1.2'
   # for JWKS caching
-  spec.add_dependency 'rails', '~> 7.0.6'
+  spec.add_dependency 'rails', '>= 6', '< 9'
   # for logging
   spec.add_dependency 'rails_semantic_logger', '~> 4.12'
 


### PR DESCRIPTION
Changed rails dependency version to allow Rails version 7 and 8. This change is required to allow bumping rails version in repo. 